### PR TITLE
Exposing image-id header

### DIFF
--- a/main.py
+++ b/main.py
@@ -43,6 +43,7 @@ app.add_middleware(
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
+    expose_headers=["Image-ID"],
 )
 
 @app.get(


### PR DESCRIPTION
This pull request includes a minor change to the `main.py` file. The change adds the `expose_headers` parameter to the CORS configuration to expose the `Image-ID` header.